### PR TITLE
Add VIN field info tooltip (closes #8)

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -49,7 +49,7 @@ const filterFields: { key: keyof SearchFilters; label: string; helpText?: string
   { key: "ROAD_TRANSPORT_CODE", label: "Road Code" },
   { key: "VEHICLE_USAGE", label: "Usage" },
   { key: "NZ_ASSEMBLED", label: "NZ Assembled" },
-  { key: "VIN11", label: "VIN" },
+  { key: "VIN11", label: "VIN", helpText: "A VIN (Vehicle Identification Number) is the 17-character identifier unique to each vehicle. NZ's Motor Vehicle Register exposes the last 11 characters (VIN11), so enter the final 11 characters here. You can find the full VIN on the dashboard near the windshield, the driver's side door jamb, or your registration documents." },
 ];
 
 const resultColumns: { key: keyof Vehicle; label: string }[] = [


### PR DESCRIPTION
Closes #8.

Adds a `helpText` to the VIN filter entry in `src/pages/Index.tsx`. The Popover/Info-icon UI is already wired up in `SearchField` and used by the Registered Region field, so all that was needed was passing the explanatory text through.

## Tooltip wording

> A VIN (Vehicle Identification Number) is the 17-character identifier unique to each vehicle. NZ's Motor Vehicle Register exposes the last 11 characters (VIN11), so enter the final 11 characters here. You can find the full VIN on the dashboard near the windshield, the driver's side door jamb, or your registration documents.

The issue suggested "17-character vehicle identifier" wording, which I kept but the field is named `VIN11` and `SearchField` validates it against `/^[A-Z0-9]{1,11}$/i`, which would be confusing for someone reading the tooltip and then getting a validation error on a full 17-char VIN. I added one sentence explaining that NZ's MVR exposes only the last 11 characters, so users know to enter the last 11.

Happy to trim that detail back to a simple "17-character identifier" if you'd rather not explain the VIN11 quirk in the tooltip easy edit, let me know.

## Screenshot

Tested locally with `npm run dev`. The Info icon appears next to the VIN label and the Popover renders the tooltip on click, matching the existing Registered Region tooltip behaviour.

## Scope

- One line changed in `src/pages/Index.tsx`.
- No new dependencies, no UI primitives added uses the existing `helpText` plumbing in `SearchField`.
